### PR TITLE
Updated tokio, worked around try_recv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ documentation = "https://docs.rs/datadog-apm"
 repository = "https://github.com/pipefy/datadog-apm-rust"
 
 [dependencies]
+futures-util = "0.3.12"
 hyper = "0.13"
 rmp-serde = "0.14.2"
 rmp = "0.8"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "0.2", features = ["macros", "sync"] }
+tokio = { version = "1.2", features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 rand = "0.3"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -59,6 +59,6 @@ async fn main() {
     client.send_trace(trace);
 
     // wait for buffer flush
-    tokio::time::delay_for(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
     println!("trace sent");
 }


### PR DESCRIPTION
I updated Tokio to 1.2.0. They removed `try_recv` because it could spuriously delay a message past a poll checkpoint but nothing should ever be lost. On that basis, I recovered the original `try_recv` behavior using a suggestion from a GitHub issue. I don't think delaying messages should be a big deal.

See these references:
- https://github.com/tokio-rs/tokio/pull/3263
- https://github.com/tokio-rs/tokio/issues/3350