### PR TITLE
Update default trace endpoint and allow downgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime};
 
 #[tokio::main]
 async fn main() {
-    let client = Client::new(Config {
+    let mut client = Client::new(Config {
         env: Some("production".to_string()),
         service: "my-crate".to_string(),
         ..Default::default()

--- a/src/client.rs
+++ b/src/client.rs
@@ -74,14 +74,14 @@ impl Client {
         client
     }
 
-    pub fn send_trace(mut self, trace: Trace) {
+    pub fn send_trace(&mut self, trace: Trace) {
         match self.buffer_sender.try_send(trace) {
             Ok(_) => trace!("trace enqueued"),
             Err(err) => warn!("could not enqueue trace: {:?}", err),
         };
     }
 
-    async fn send_traces(mut self, traces: Vec<Trace>) {
+    async fn send_traces(&mut self, traces: Vec<Trace>) {
         for _ in 0..Client::MAX_RETRIES {
             match self.do_send_traces(&traces).await {
                 ShouldRetry::True => debug!("try sending traces again"),

--- a/src/client.rs
+++ b/src/client.rs
@@ -90,7 +90,7 @@ impl Client {
         }
     }
 
-    async fn do_send_traces(&mut self, traces: &Vec<Trace>) -> ShouldRetry {
+    async fn do_send_traces(&mut self, traces: &[Trace]) -> ShouldRetry {
         let mut should_retry = ShouldRetry::False;
 
         match self.http_client.request(self.build_request(traces)).await {
@@ -110,7 +110,7 @@ impl Client {
         should_retry
     }
 
-    fn build_request(&self, traces: &Vec<Trace>) -> Request<Body> {
+    fn build_request(&self, traces: &[Trace]) -> Request<Body> {
         let raw_traces = traces
             .iter()
             .map(|trace| map_to_raw_spans(trace, self.env.clone(), self.service.clone()))
@@ -268,13 +268,13 @@ fn spawn_consume_buffer_task(mut buffer_receiver: mpsc::Receiver<Trace>, client:
         }
 
         fn flush_max_interval_has_passed<T>(
-            buffer: &Vec<T>,
+            buffer: &[T],
             client: &Client,
             last_flushed_at: SystemTime,
         ) -> bool {
-            buffer.len() > 0
+            !buffer.is_empty()
                 && SystemTime::now().duration_since(last_flushed_at).unwrap()
-                > client.buffer_flush_max_interval
+                    > client.buffer_flush_max_interval
         }
     });
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -243,13 +243,11 @@ enum ShouldRetry {
     False,
 }
 
-fn spawn_consume_buffer_task(mut buffer_receiver: mpsc::Receiver<Trace>, client: Client) {
+fn spawn_consume_buffer_task(mut buffer_receiver: mpsc::Receiver<Trace>, mut client: Client) {
     tokio::spawn(async move {
         let mut buffer = Vec::with_capacity(client.buffer_size);
         let mut last_flushed_at = SystemTime::now();
         loop {
-            let client = client.clone();
-
             match buffer_receiver.try_recv() {
                 Ok(trace) => {
                     buffer.push(trace);
@@ -371,7 +369,7 @@ mod tests {
             service: String::from("service_name"),
             ..Default::default()
         };
-        let client = Client::new(config);
+        let mut client = Client::new(config);
         let trace = a_trace();
         client.send_trace(trace);
     }


### PR DESCRIPTION
This is for parity with the Ruby ddtrace gem: https://github.com/DataDog/dd-trace-rb/blob/d3a6a87743546fe5f428db4b4535a5ad12c75138/lib/ddtrace/transport/traces.rb#L113-L126

I'm having some trouble unit testing, so I'm going to pull my branch into another service I have and try testing it out in a more "integrated" fashion